### PR TITLE
Harden Docker publish steps to avoid secret exposure on merge-queue runs

### DIFF
--- a/.github/workflows/ci-docker-all-in-one.yml
+++ b/.github/workflows/ci-docker-all-in-one.yml
@@ -55,8 +55,14 @@ jobs:
         esac
 
     - name: Build, test, and publish all-in-one image
+      if: github.event_name == 'push' && github.ref_name == 'main'
       run: |
         bash scripts/build/build-all-in-one-image.sh ${{ env.BUILD_FLAGS }} v2
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+
+    - name: Build and test all-in-one image (no publish)
+      if: github.event_name != 'push' || github.ref_name != 'main'
+      run: |
+        bash scripts/build/build-all-in-one-image.sh ${{ env.BUILD_FLAGS }} v2

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -41,8 +41,13 @@ jobs:
       run: bash scripts/build/build-upload-docker-images.sh -D -p linux/amd64
 
     - name: Build and upload all container images
-      if: github.ref_name == 'main'
+      if: github.event_name == 'push' && github.ref_name == 'main'
       run: bash scripts/build/build-upload-docker-images.sh
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+
+    - name: Build all container images (no upload)
+      if: github.event_name != 'push' || github.ref_name != 'main'
+      # -D disables images with debugger
+      run: bash scripts/build/build-upload-docker-images.sh -D

--- a/.github/workflows/ci-docker-hotrod.yml
+++ b/.github/workflows/ci-docker-hotrod.yml
@@ -59,7 +59,12 @@ jobs:
       uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1
 
     - name: Build, test, and publish hotrod image
+      if: github.event_name == 'push' && github.ref_name == 'main'
       run:  bash scripts/build/build-hotrod-image.sh ${{ env.BUILD_FLAGS }} -r ${{ matrix.runtime }}
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+
+    - name: Build and test hotrod image (no publish)
+      if: github.event_name != 'push' || github.ref_name != 'main'
+      run:  bash scripts/build/build-hotrod-image.sh ${{ env.BUILD_FLAGS }} -r ${{ matrix.runtime }}


### PR DESCRIPTION
### Motivation
- The CI workflows were exposing registry secrets (`DOCKERHUB_TOKEN`, `QUAY_TOKEN`) during runs triggered by `merge_group` (merge-queue) and other non-push events, allowing queued PR code to execute secret-backed publish steps.
- The change aims to prevent secret exposure while preserving image build/test coverage for PRs and merge-queue validation.

### Description
- Added an `if: github.event_name == 'push' && github.ref_name == 'main'` guard to publish steps that require registry secrets in `/.github/workflows/ci-docker-build.yml`, `/.github/workflows/ci-docker-all-in-one.yml`, and `/.github/workflows/ci-docker-hotrod.yml` so publishing runs only on pushes to `main`.
- Added non-publishing fallback build/test steps for non-`push main` events that run the same build scripts without injecting `DOCKERHUB_TOKEN` or `QUAY_TOKEN`, preserving CI validation for `pull_request` and `merge_group` runs.
- The modifications are minimal and target only the secret-bearing publish steps to limit the blast radius of merge-queue runs.

### Testing
- Ran `make fmt` which completed successfully.
- Ran `make lint` which was attempted but encountered issues due to a parallel `golangci-lint` process lock and did not complete cleanly in this environment.
- Ran `make test` which executed many package tests successfully, but some tests in `cmd/anonymizer/app/query` failed due to environment `403 Forbidden` connection errors; these failures are environment-related and not caused by the workflow YAML changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33cf05f448326b7c1e46251a2bc13)