### PR TITLE
jaegermcp: enforce MaxSpanDetailsPerRequest in get_span_details handler

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details.go
@@ -30,15 +30,18 @@ type queryServiceGetTracesInterface interface {
 // This tool fetches full OTLP details (attributes, events, links, status) for specific spans
 // within a trace, allowing deep inspection of individual span data for debugging and analysis.
 type getSpanDetailsHandler struct {
-	queryService queryServiceGetTracesInterface
+	queryService             queryServiceGetTracesInterface
+	maxSpanDetailsPerRequest int
 }
 
 // NewGetSpanDetailsHandler creates a new get_span_details handler and returns the handler function.
 func NewGetSpanDetailsHandler(
 	queryService *querysvc.QueryService,
+	maxSpanDetailsPerRequest int,
 ) mcp.ToolHandlerFor[types.GetSpanDetailsInput, types.GetSpanDetailsOutput] {
 	h := &getSpanDetailsHandler{
-		queryService: queryService,
+		queryService:             queryService,
+		maxSpanDetailsPerRequest: maxSpanDetailsPerRequest,
 	}
 	return h.handle
 }
@@ -115,7 +118,12 @@ func (h *getSpanDetailsHandler) handle(
 }
 
 // buildQuery converts GetSpanDetailsInput to querysvc.GetTraceParams.
-func (*getSpanDetailsHandler) buildQuery(input types.GetSpanDetailsInput) (querysvc.GetTraceParams, error) {
+func (h *getSpanDetailsHandler) buildQuery(input types.GetSpanDetailsInput) (querysvc.GetTraceParams, error) {
+	maxSpanDetailsPerRequest := h.maxSpanDetailsPerRequest
+	if maxSpanDetailsPerRequest <= 0 {
+		maxSpanDetailsPerRequest = 20
+	}
+
 	// Validate input
 	if input.TraceID == "" {
 		return querysvc.GetTraceParams{}, errors.New("trace_id is required")
@@ -123,6 +131,13 @@ func (*getSpanDetailsHandler) buildQuery(input types.GetSpanDetailsInput) (query
 
 	if len(input.SpanIDs) == 0 {
 		return querysvc.GetTraceParams{}, errors.New("span_ids is required and must not be empty")
+	}
+
+	if len(input.SpanIDs) > maxSpanDetailsPerRequest {
+		return querysvc.GetTraceParams{}, fmt.Errorf(
+			"span_ids must not exceed %d items",
+			maxSpanDetailsPerRequest,
+		)
 	}
 
 	traceID, err := parseTraceID(input.TraceID)

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details_test.go
@@ -166,7 +166,7 @@ func TestGetSpanDetailsHandler_Handle_FiltersBySpanIDs(t *testing.T) {
 }
 
 func TestGetSpanDetailsHandler_Handle_MissingTraceID(t *testing.T) {
-	handler := NewGetSpanDetailsHandler(nil)
+	handler := NewGetSpanDetailsHandler(nil, 20)
 
 	input := types.GetSpanDetailsInput{
 		SpanIDs: []string{spanIDToHex("span001")},
@@ -179,7 +179,7 @@ func TestGetSpanDetailsHandler_Handle_MissingTraceID(t *testing.T) {
 }
 
 func TestGetSpanDetailsHandler_Handle_MissingSpanIDs(t *testing.T) {
-	handler := NewGetSpanDetailsHandler(nil)
+	handler := NewGetSpanDetailsHandler(nil, 20)
 
 	input := types.GetSpanDetailsInput{
 		TraceID: testTraceID,
@@ -192,8 +192,22 @@ func TestGetSpanDetailsHandler_Handle_MissingSpanIDs(t *testing.T) {
 	assert.Contains(t, err.Error(), "span_ids is required")
 }
 
+func TestGetSpanDetailsHandler_Handle_TooManySpanIDs(t *testing.T) {
+	handler := NewGetSpanDetailsHandler(nil, 2)
+
+	input := types.GetSpanDetailsInput{
+		TraceID: testTraceID,
+		SpanIDs: []string{spanIDToHex("span001"), spanIDToHex("span002"), spanIDToHex("span003")},
+	}
+
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "span_ids must not exceed 2 items")
+}
+
 func TestGetSpanDetailsHandler_Handle_InvalidTraceID(t *testing.T) {
-	handler := NewGetSpanDetailsHandler(nil)
+	handler := NewGetSpanDetailsHandler(nil, 20)
 
 	input := types.GetSpanDetailsInput{
 		TraceID: "invalid-trace-id",

--- a/cmd/jaeger/internal/extension/jaegermcp/server.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server.go
@@ -163,7 +163,7 @@ func (s *server) registerTools() {
 	}, searchTracesHandler)
 
 	// Get span details tool
-	getSpanDetailsHandler := handlers.NewGetSpanDetailsHandler(s.queryAPI)
+	getSpanDetailsHandler := handlers.NewGetSpanDetailsHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest)
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name:        "get_span_details",
 		Description: "Fetch full details (attributes, events, links, status) for specific spans.",


### PR DESCRIPTION
### Motivation

- The `get_span_details` MCP handler accepted unbounded `span_ids` lists and allocated structures sized to the input length, enabling a remote client to trigger excessive memory/CPU use (DoS). 
- The MCP config already exposes `MaxSpanDetailsPerRequest`, but the handler did not read or enforce it, so the configured limit was ineffective.

### Description

- Wire `MaxSpanDetailsPerRequest` into the `get_span_details` handler by adding a `maxSpanDetailsPerRequest` field and a constructor parameter in `NewGetSpanDetailsHandler`.
- Enforce the configured maximum in `buildQuery` by rejecting requests where `len(input.SpanIDs) > maxSpanDetailsPerRequest`, with a safe fallback default of `20` when unset or non-positive.
- Update the server `registerTools` call site to pass `s.config.MaxSpanDetailsPerRequest` into the handler, and update handler tests to use the new constructor signature.
- Add a regression test `TestGetSpanDetailsHandler_Handle_TooManySpanIDs` that verifies oversized `span_ids` are rejected with a clear error.

### Testing

- Ran `make fmt` and formatting checks succeeded (`make fmt` ✅).
- Ran the handler unit tests with `go test ./cmd/jaeger/internal/extension/jaegermcp/internal/handlers -count=1` and they passed (including the new regression test) (`ok`).
- Ran `make lint` which failed due to pre-existing repo-wide lint issues unrelated to this change (existing `revive` unhandled-error findings), so lint is unchanged by this patch (baseline failure).
- Ran full `make test` which failed due to unrelated existing test failures in other packages (external-connection / fixture issues), so end-to-end suite status is unchanged by this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b314c7b3208326a1075660a6819acb)