### PR TITLE
jaegermcp: restrict CORS to explicitly allowed origins

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/config.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/config.go
@@ -25,6 +25,10 @@ type Config struct {
 
 	// MaxSearchResults limits the number of trace search results.
 	MaxSearchResults int `mapstructure:"max_search_results" valid:"range(1|1000)"`
+
+	// CORSAllowedOrigins controls which browser origins are allowed to call MCP endpoints.
+	// Empty means CORS is disabled.
+	CORSAllowedOrigins []string `mapstructure:"cors_allowed_origins"`
 }
 
 // Validate checks if the configuration is valid.

--- a/cmd/jaeger/internal/extension/jaegermcp/factory.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/factory.go
@@ -48,6 +48,7 @@ func createDefaultConfig() component.Config {
 		ServerVersion:            ver,
 		MaxSpanDetailsPerRequest: 20,
 		MaxSearchResults:         100,
+		CORSAllowedOrigins:       nil,
 	}
 }
 

--- a/cmd/jaeger/internal/extension/jaegermcp/server.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server.go
@@ -101,8 +101,13 @@ func (s *server) Start(ctx context.Context, host component.Host) error {
 		w.Write([]byte("MCP server is running"))
 	})
 
+	handler := http.Handler(mux)
+	if len(s.config.CORSAllowedOrigins) > 0 {
+		handler = corsMiddleware(mux, s.config.CORSAllowedOrigins)
+	}
+
 	s.httpServer = &http.Server{
-		Handler:           corsMiddleware(mux),
+		Handler:           handler,
 		ReadHeaderTimeout: 30 * time.Second,
 	}
 
@@ -212,19 +217,26 @@ func (s *server) healthTool(
 	}, nil
 }
 
-// corsMiddleware wraps an http.Handler to add CORS headers.
-// This is required for browser-based MCP clients like the MCP Inspector.
-func corsMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID")
-		w.Header().Set("Access-Control-Expose-Headers", "Mcp-Session-Id")
+// corsMiddleware wraps an http.Handler to add CORS headers for configured origins.
+func corsMiddleware(next http.Handler, allowedOrigins []string) http.Handler {
+	allowed := make(map[string]struct{}, len(allowedOrigins))
+	for _, origin := range allowedOrigins {
+		allowed[origin] = struct{}{}
+	}
 
-		// Handle preflight requests
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if _, ok := allowed[origin]; ok {
+			w.Header().Set("Vary", "Origin")
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID")
+			w.Header().Set("Access-Control-Expose-Headers", "Mcp-Session-Id")
+
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
 		}
 
 		next.ServeHTTP(w, r)

--- a/cmd/jaeger/internal/extension/jaegermcp/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server_test.go
@@ -704,8 +704,9 @@ func TestCORSPreflight(t *testing.T) {
 				Transport: confignet.TransportTypeTCP,
 			},
 		},
-		ServerName:    "jaeger-test",
-		ServerVersion: "1.0.0",
+		ServerName:         "jaeger-test",
+		ServerVersion:      "1.0.0",
+		CORSAllowedOrigins: []string{"http://localhost:3000"},
 	}
 
 	server := newServer(config, componenttest.NewNopTelemetrySettings())
@@ -727,6 +728,41 @@ func TestCORSPreflight(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "http://localhost:3000", resp.Header.Get("Access-Control-Allow-Origin"))
 	assert.Equal(t, "GET, POST, DELETE, OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
+}
+
+func TestCORSPreflightDisallowedOrigin(t *testing.T) {
+	config := &Config{
+		HTTP: confighttp.ServerConfig{
+			NetAddr: confignet.AddrConfig{
+				Endpoint:  "localhost:0",
+				Transport: confignet.TransportTypeTCP,
+			},
+		},
+		ServerName:         "jaeger-test",
+		ServerVersion:      "1.0.0",
+		CORSAllowedOrigins: []string{"http://localhost:3000"},
+	}
+
+	server := newServer(config, componenttest.NewNopTelemetrySettings())
+	host := newMockHost()
+	err := server.Start(context.Background(), host)
+	require.NoError(t, err)
+	defer server.Shutdown(context.Background())
+
+	addr := server.listener.Addr().String()
+	url := fmt.Sprintf("http://%s/mcp", addr)
+
+	req, err := http.NewRequest(http.MethodOptions, url, http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "http://evil.example")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.NotEqual(t, http.StatusNoContent, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
 }


### PR DESCRIPTION
### Motivation
- The MCP HTTP server previously applied a hardcoded wildcard CORS policy, allowing any website to make cross-origin requests and read trace data, creating a data-exfiltration vector.

### Description
- Add `CORSAllowedOrigins []string` (config key `cors_allowed_origins`) to the Jaeger MCP extension config and keep it nil by default to disable CORS.
- Only wrap the MCP HTTP handler with CORS middleware when the allowlist is non-empty, so CORS is opt-in rather than always enabled.
- Replace the unconditional `Access-Control-Allow-Origin: *` behavior with an allowlist-based middleware that sets `Vary: Origin` and returns `Access-Control-Allow-Origin`/preflight responses only for configured origins.
- Update unit tests to verify allowed-origin preflight behavior and disallowed-origin behavior.

### Testing
- `make fmt` completed successfully.
- `make lint` was started and progressed through the lint pipeline but did not fully complete within this session.
- `make test` was started but did not fully complete within this session due to environment time limits.
- Targeted unit tests `go test ./cmd/jaeger/internal/extension/jaegermcp -run 'TestCORSPreflight|TestCORSPreflightDisallowedOrigin'` were executed but timed out in this environment before finishing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b312b285448326b9f7f9711b45acba)