### PR TITLE
harden get_critical_path against recursion/complexity DoS

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath/criticalpath.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath/criticalpath.go
@@ -5,6 +5,7 @@ package criticalpath
 
 import (
 	"errors"
+	"sort"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -47,42 +48,41 @@ func computeCriticalPath(
 	criticalPath []Section,
 	returningChildStartTime *uint64,
 ) []Section {
-	currentSpan, ok := spanMap[spanID]
-	if !ok {
-		return criticalPath
-	}
+	selector := newChildSelector(spanMap)
 
-	lastFinishingChildSpan := findLastFinishingChildSpan(spanMap, currentSpan, returningChildStartTime)
+	currentSpanID := spanID
+	for {
+		currentSpan, ok := spanMap[currentSpanID]
+		if !ok {
+			return criticalPath
+		}
 
-	var spanCriticalSection Section
+		lastFinishingChildSpan := selector.findLastFinishingChild(currentSpan, returningChildStartTime)
 
-	if lastFinishingChildSpan != nil {
-		// There is a last finishing child
 		endTime := currentSpan.StartTime + currentSpan.Duration
 		if returningChildStartTime != nil {
 			endTime = *returningChildStartTime
 		}
 
-		spanCriticalSection = Section{
-			SpanID:       currentSpan.SpanID.String(),
-			SectionStart: lastFinishingChildSpan.StartTime + lastFinishingChildSpan.Duration,
-			SectionEnd:   endTime,
+		if lastFinishingChildSpan != nil {
+			spanCriticalSection := Section{
+				SpanID:       currentSpan.SpanID.String(),
+				SectionStart: lastFinishingChildSpan.StartTime + lastFinishingChildSpan.Duration,
+				SectionEnd:   endTime,
+			}
+
+			if spanCriticalSection.SectionStart != spanCriticalSection.SectionEnd {
+				criticalPath = append(criticalPath, spanCriticalSection)
+			}
+
+			// Now focus shifts to the lastFinishingChildSpan of current span.
+			currentSpanID = lastFinishingChildSpan.SpanID
+			returningChildStartTime = nil
+			continue
 		}
 
-		if spanCriticalSection.SectionStart != spanCriticalSection.SectionEnd {
-			criticalPath = append(criticalPath, spanCriticalSection)
-		}
-
-		// Now focus shifts to the lastFinishingChildSpan of current span
-		criticalPath = computeCriticalPath(spanMap, lastFinishingChildSpan.SpanID, criticalPath, nil)
-	} else {
-		// If there is no last finishing child then total section up to startTime of span is on critical path
-		endTime := currentSpan.StartTime + currentSpan.Duration
-		if returningChildStartTime != nil {
-			endTime = *returningChildStartTime
-		}
-
-		spanCriticalSection = Section{
+		// If there is no last finishing child then total section up to startTime of span is on critical path.
+		spanCriticalSection := Section{
 			SpanID:       currentSpan.SpanID.String(),
 			SectionStart: currentSpan.StartTime,
 			SectionEnd:   endTime,
@@ -92,16 +92,80 @@ func computeCriticalPath(
 			criticalPath = append(criticalPath, spanCriticalSection)
 		}
 
-		// Now as there are no LFCs focus shifts to parent span from startTime of span
-		// return from recursion and walk backwards to one level depth to parent span
-		// provide span's startTime as returningChildStartTime
-		if len(currentSpan.References) > 0 {
-			parentSpanID := currentSpan.References[0].SpanID
-			criticalPath = computeCriticalPath(spanMap, parentSpanID, criticalPath, &currentSpan.StartTime)
+		// Now as there are no LFCs focus shifts to parent span from startTime of span.
+		if len(currentSpan.References) == 0 {
+			return criticalPath
 		}
+
+		parentSpanID := currentSpan.References[0].SpanID
+		returningChildStartTime = &currentSpan.StartTime
+		currentSpanID = parentSpanID
+	}
+}
+
+type childSelector struct {
+	spanMap map[pcommon.SpanID]CPSpan
+	state   map[pcommon.SpanID]childSelectorState
+}
+
+type childSelectorState struct {
+	children []CPSpan
+	nextIdx  int
+}
+
+func newChildSelector(spanMap map[pcommon.SpanID]CPSpan) *childSelector {
+	return &childSelector{
+		spanMap: spanMap,
+		state:   make(map[pcommon.SpanID]childSelectorState),
+	}
+}
+
+func (s *childSelector) findLastFinishingChild(currentSpan CPSpan, returningChildStartTime *uint64) *CPSpan {
+	state, ok := s.state[currentSpan.SpanID]
+	if !ok {
+		state = childSelectorState{children: sortedChildrenByEndTimeDesc(currentSpan, s.spanMap)}
 	}
 
-	return criticalPath
+	for state.nextIdx < len(state.children) {
+		candidate := state.children[state.nextIdx]
+		candidateEnd := candidate.StartTime + candidate.Duration
+
+		if returningChildStartTime != nil && candidateEnd >= *returningChildStartTime {
+			state.nextIdx++
+			continue
+		}
+
+		state.nextIdx++
+		s.state[currentSpan.SpanID] = state
+		child := candidate
+		return &child
+	}
+
+	s.state[currentSpan.SpanID] = state
+	return nil
+}
+
+func sortedChildrenByEndTimeDesc(currentSpan CPSpan, spanMap map[pcommon.SpanID]CPSpan) []CPSpan {
+	children := make([]CPSpan, 0, len(currentSpan.ChildSpanIDs))
+
+	for _, childID := range currentSpan.ChildSpanIDs {
+		childSpan, ok := spanMap[childID]
+		if !ok {
+			continue
+		}
+		children = append(children, childSpan)
+	}
+
+	sort.Slice(children, func(i, j int) bool {
+		leftEndTime := children[i].StartTime + children[i].Duration
+		rightEndTime := children[j].StartTime + children[j].Duration
+		if leftEndTime != rightEndTime {
+			return leftEndTime > rightEndTime
+		}
+		return children[i].StartTime > children[j].StartTime
+	})
+
+	return children
 }
 
 // ComputeCriticalPathFromTraces computes the critical path for a given trace

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath/criticalpath_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath/criticalpath_test.go
@@ -191,3 +191,31 @@ func TestFindLastFinishingChildSpan_MissingChild(t *testing.T) {
 	result := findLastFinishingChildSpan(spanMap, parentSpan, nil)
 	assert.Nil(t, result)
 }
+
+func TestComputeCriticalPath_FlatTraceLargeFanout(t *testing.T) {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	root := ss.Spans().AppendEmpty()
+	root.SetSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1})
+	root.SetTraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+	root.SetStartTimestamp(pcommon.Timestamp(0))
+	root.SetEndTimestamp(pcommon.Timestamp(1000000 * 1000))
+
+	const fanout = 10000
+	for i := 0; i < fanout; i++ {
+		child := ss.Spans().AppendEmpty()
+		child.SetSpanID([8]byte{0, 0, 0, 0, byte(i >> 16), byte(i >> 8), byte(i), 2})
+		child.SetParentSpanID(root.SpanID())
+		child.SetTraceID(root.TraceID())
+		start := uint64(i + 1)
+		child.SetStartTimestamp(pcommon.Timestamp(start * 1000))
+		child.SetEndTimestamp(pcommon.Timestamp((start + 1) * 1000))
+	}
+
+	criticalPath, err := ComputeCriticalPathFromTraces(traces)
+	require.NoError(t, err)
+	// one section per child and one trailing root section
+	assert.Len(t, criticalPath, fanout+1)
+}


### PR DESCRIPTION
### Motivation
- The previous critical path implementation used recursive parent↔child bouncing and rescanned all siblings on each return, which creates O(N^2) work and deep recursion for attacker-controlled high fan-out traces and exposes the MCP server to CPU/stack DoS.

### Description
- Replaced recursive parent/child bouncing in `computeCriticalPath` with an iterative traversal loop to avoid deep recursion and repeated rescans (file `criticalpath/criticalpath.go`).
- Introduced a `childSelector` cache that pre-sorts each parent's children by end time and advances via an index to avoid full sibling rescans (functions `newChildSelector`, `findLastFinishingChild`, and `sortedChildrenByEndTimeDesc`).
- Kept existing critical-path section semantics and preserved handling of `returningChildStartTime` while eliminating quadratic behavior.
- Added a large-fanout regression test `TestComputeCriticalPath_FlatTraceLargeFanout` to exercise flat traces with many siblings (file `criticalpath/criticalpath_test.go`).

### Testing
- `make fmt` completed successfully in this environment.
- Unit tests for the critical-path package were run with `go test ./cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath` and passed.
- `make lint` and the repository-wide `make test` were started but the long-running lint/test jobs did not complete within this environment, so full-repo linting and test-suite confirmation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b314c68d548326a83838da01fab6a2)