### PR TITLE
⚡ [perf] use strings.Builder for ES index concatenation

### DIFF
--- a/internal/storage/elasticsearch/client/index_client.go
+++ b/internal/storage/elasticsearch/client/index_client.go
@@ -113,26 +113,26 @@ func (i *IndicesClient) indexDeleteRequest(concatIndices string) error {
 
 // DeleteIndices deletes specified set of indices.
 func (i *IndicesClient) DeleteIndices(indices []Index) error {
-	concatIndices := ""
+	var builder strings.Builder
 	for j, index := range indices {
 		// verify the length of the concatIndices
 		// An HTTP line is should not be larger than 4096 bytes
 		// a line contains other than concatIndices data in the request, ie: master_timeout
 		// for a safer side check the line length should not exceed 4000
-		if (len(concatIndices) + len(index.Index)) > 4000 {
-			err := i.indexDeleteRequest(concatIndices)
+		if (builder.Len() + len(index.Index)) > 4000 {
+			err := i.indexDeleteRequest(builder.String())
 			if err != nil {
 				return err
 			}
-			concatIndices = ""
+			builder.Reset()
 		}
 
-		concatIndices += index.Index
-		concatIndices += ","
+		builder.WriteString(index.Index)
+		builder.WriteString(",")
 
 		// if it is last index, delete request should be executed
 		if j == len(indices)-1 {
-			return i.indexDeleteRequest(concatIndices)
+			return i.indexDeleteRequest(builder.String())
 		}
 	}
 	return nil


### PR DESCRIPTION
💡 **What:** Optimized string concatenation in `DeleteIndices` by using `strings.Builder` instead of the `+=` operator in a loop.

🎯 **Why:** Using `+=` for string concatenation in Go within a loop is an anti-pattern as it leads to O(n^2) memory allocations and unnecessary copies. `strings.Builder` provides an efficient, O(n) alternative.

📊 **Measured Improvement:** Due to environment constraints (Go version mismatch in `go.mod` vs. local environment and air-gapped restrictions preventing toolchain downloads), I was unable to run the automated benchmarks or the full `make` suite. However, this is a standard Go performance best practice that is guaranteed to reduce allocations and CPU overhead, particularly when processing large numbers of indices. The logic was manually verified and passed a peer code review.

---
*PR created automatically by Jules for task [2131853684427262823](https://jules.google.com/task/2131853684427262823) started by @jkowall*