### PR TITLE
🧹 Refactor loadStrategies to global jjson utility

### DIFF
--- a/internal/jjson/jjson.go
+++ b/internal/jjson/jjson.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jjson
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Unmarshal unmarshals data into v and returns a wrapped error with the provided description.
+func Unmarshal(data []byte, v any, desc string) error {
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("failed to unmarshal %s: %w", desc, err)
+	}
+	return nil
+}

--- a/internal/jjson/jjson_test.go
+++ b/internal/jjson/jjson_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jjson
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshal(t *testing.T) {
+	type testStruct struct {
+		Foo string `json:"foo"`
+	}
+
+	t.Run("success", func(t *testing.T) {
+		var v testStruct
+		err := Unmarshal([]byte(`{"foo":"bar"}`), &v, "test")
+		assert.NoError(t, err)
+		assert.Equal(t, "bar", v.Foo)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		var v testStruct
+		err := Unmarshal([]byte(`{"foo":1}`), &v, "test")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal test")
+	})
+}

--- a/internal/sampling/samplingstrategy/file/provider.go
+++ b/internal/sampling/samplingstrategy/file/provider.go
@@ -6,8 +6,8 @@ package file
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
+	"github.com/jaegertracing/jaeger/internal/jjson"
 	"net/http"
 	"net/url"
 	"os"
@@ -58,8 +58,12 @@ func NewProvider(options Options, logger *zap.Logger) (samplingstrategy.Provider
 	}
 
 	loadFn := h.samplingStrategyLoader(options.StrategiesFile)
-	strategies, err := loadStrategies(loadFn)
+	strategyBytes, err := loadFn()
 	if err != nil {
+		return nil, err
+	}
+	var strategies *strategies
+	if err := jjson.Unmarshal(strategyBytes, &strategies, "strategies"); err != nil {
 		return nil, err
 	} else if strategies == nil {
 		h.logger.Info("No sampling strategies found or URL is unavailable, using defaults")
@@ -176,26 +180,12 @@ func (h *samplingProvider) reloadSamplingStrategy(loadFn strategyLoader, lastVal
 
 func (h *samplingProvider) updateSamplingStrategy(dataBytes []byte) error {
 	var strategies strategies
-	if err := json.Unmarshal(dataBytes, &strategies); err != nil {
-		return fmt.Errorf("failed to unmarshal sampling strategies: %w", err)
+	if err := jjson.Unmarshal(dataBytes, &strategies, "sampling strategies"); err != nil {
+		return err
 	}
 	h.parseStrategies(&strategies)
 	h.logger.Info("Updated sampling strategies:" + string(dataBytes))
 	return nil
-}
-
-// TODO good candidate for a global util function
-func loadStrategies(loadFn strategyLoader) (*strategies, error) {
-	strategyBytes, err := loadFn()
-	if err != nil {
-		return nil, err
-	}
-
-	var strategies *strategies
-	if err := json.Unmarshal(strategyBytes, &strategies); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal strategies: %w", err)
-	}
-	return strategies, nil
 }
 
 func (h *samplingProvider) parseStrategies(strategies *strategies) {


### PR DESCRIPTION
The code health improvement task involved extracting a common JSON unmarshaling pattern into a global utility function.

🎯 **What:**
- Created a new internal package `internal/jjson` with an `Unmarshal` function that wraps `json.Unmarshal` and provides standardized error formatting.
- Refactored `internal/sampling/samplingstrategy/file/provider.go` to use `jjson.Unmarshal`.
- Removed the local `loadStrategies` function and the `encoding/json` import in `provider.go`.

💡 **Why:**
- Improves maintainability by centralizing common logic.
- Standardizes error messages for JSON unmarshaling failures.
- Reduces code duplication in the sampling strategy provider.

✅ **Verification:**
- Verified the creation and contents of the new `jjson` package.
- Confirmed that all call sites in `provider.go` were updated and that no unused imports remained.
- Ensured the syntax and logic were correct through manual inspection and file reading.

✨ **Result:**
- A cleaner, more maintainable sampling strategy provider with a reusable JSON utility for future use.

---
*PR created automatically by Jules for task [13536429558432521506](https://jules.google.com/task/13536429558432521506) started by @jkowall*