### PR TITLE
Remove GetOperationsMissingSpanKind workaround from badger tests

### DIFF
--- a/cmd/jaeger/internal/integration/badger_test.go
+++ b/cmd/jaeger/internal/integration/badger_test.go
@@ -17,10 +17,6 @@ func TestBadgerStorage(t *testing.T) {
 		PropagateEnvVars: []string{"BADGER_METRICS_UPDATE_INTERVAL"},
 		StorageIntegration: integration.StorageIntegration{
 			CleanUp: purge,
-
-			// TODO: remove this once badger supports returning spanKind from GetOperations
-			// Cf https://github.com/jaegertracing/jaeger/issues/1922
-			GetOperationsMissingSpanKind: true,
 		},
 	}
 	s.e2eInitialize(t, "badger")

--- a/internal/storage/integration/badgerstore_test.go
+++ b/internal/storage/integration/badgerstore_test.go
@@ -54,10 +54,7 @@ func TestBadgerStorage(t *testing.T) {
 		testutils.VerifyGoLeaksOnce(t)
 	})
 	s := &BadgerIntegrationStorage{
-		StorageIntegration: StorageIntegration{
-			// TODO: remove this badger supports returning spanKind from GetOperations
-			GetOperationsMissingSpanKind: true,
-		},
+		StorageIntegration: StorageIntegration{},
 	}
 	s.CleanUp = s.cleanUp
 	s.initialize(t)

--- a/internal/storage/v1/badger/spanstore/cache.go
+++ b/internal/storage/v1/badger/spanstore/cache.go
@@ -18,7 +18,7 @@ type CacheStore struct {
 	// Given the small amount of data these will store, we use the same structure as the memory store
 	cacheLock  sync.Mutex // write heavy - Mutex is faster than RWMutex for writes
 	services   map[string]uint64
-	operations map[string]map[string]uint64
+	operations map[string]map[spanstore.Operation]uint64
 
 	store *badger.DB
 	ttl   time.Duration
@@ -28,7 +28,7 @@ type CacheStore struct {
 func NewCacheStore(db *badger.DB, ttl time.Duration) *CacheStore {
 	cs := &CacheStore{
 		services:   make(map[string]uint64),
-		operations: make(map[string]map[string]uint64),
+		operations: make(map[string]map[spanstore.Operation]uint64),
 		ttl:        ttl,
 		store:      db,
 	}
@@ -48,35 +48,36 @@ func (c *CacheStore) AddService(service string, keyTTL uint64) {
 }
 
 // AddOperation adds the cache with operation names with most updated expiration time
-func (c *CacheStore) AddOperation(service, operation string, keyTTL uint64) {
+func (c *CacheStore) AddOperation(service, operation, spanKind string, keyTTL uint64) {
 	c.cacheLock.Lock()
 	defer c.cacheLock.Unlock()
 	if _, found := c.operations[service]; !found {
-		c.operations[service] = make(map[string]uint64)
+		c.operations[service] = make(map[spanstore.Operation]uint64)
 	}
-	if v, found := c.operations[service][operation]; found {
+	op := spanstore.Operation{Name: operation, SpanKind: spanKind}
+	if v, found := c.operations[service][op]; found {
 		if v > keyTTL {
 			return
 		}
 	}
-	c.operations[service][operation] = keyTTL
+	c.operations[service][op] = keyTTL
 }
 
 // Update caches the results of service and service + operation indexes and maintains their TTL
-func (c *CacheStore) Update(service, operation string, expireTime uint64) {
+func (c *CacheStore) Update(service, operation, spanKind string, expireTime uint64) {
 	c.cacheLock.Lock()
 
 	c.services[service] = expireTime
 	if _, ok := c.operations[service]; !ok {
-		c.operations[service] = make(map[string]uint64)
+		c.operations[service] = make(map[spanstore.Operation]uint64)
 	}
-	c.operations[service][operation] = expireTime
+	op := spanstore.Operation{Name: operation, SpanKind: spanKind}
+	c.operations[service][op] = expireTime
 	c.cacheLock.Unlock()
 }
 
 // GetOperations returns all operations for a specific service & spanKind traced by Jaeger
-func (c *CacheStore) GetOperations(service string) ([]spanstore.Operation, error) {
-	operations := make([]string, 0, len(c.services))
+func (c *CacheStore) GetOperations(service, spanKind string) ([]spanstore.Operation, error) {
 	//nolint:gosec // G115
 	t := uint64(time.Now().Unix())
 	c.cacheLock.Lock()
@@ -89,26 +90,29 @@ func (c *CacheStore) GetOperations(service string) ([]spanstore.Operation, error
 			delete(c.operations, service)
 			return []spanstore.Operation{}, nil // empty slice rather than nil
 		}
-		for o, e := range c.operations[service] {
+
+		result := make([]spanstore.Operation, 0, len(c.operations[service]))
+		for op, e := range c.operations[service] {
 			if e > t {
-				operations = append(operations, o)
+				if spanKind == "" || spanKind == op.SpanKind {
+					result = append(result, op)
+				}
 			} else {
-				delete(c.operations[service], o)
+				delete(c.operations[service], op)
 			}
 		}
-	}
 
-	sort.Strings(operations)
-
-	// TODO: https://github.com/jaegertracing/jaeger/issues/1922
-	// 	- return the operations with actual spanKind
-	result := make([]spanstore.Operation, 0, len(operations))
-	for _, op := range operations {
-		result = append(result, spanstore.Operation{
-			Name: op,
+		sort.Slice(result, func(i, j int) bool {
+			if result[i].Name != result[j].Name {
+				return result[i].Name < result[j].Name
+			}
+			return result[i].SpanKind < result[j].SpanKind
 		})
+
+		return result, nil
 	}
-	return result, nil
+
+	return []spanstore.Operation{}, nil
 }
 
 // GetServices returns all services traced by Jaeger

--- a/internal/storage/v1/badger/spanstore/get_operations_test.go
+++ b/internal/storage/v1/badger/spanstore/get_operations_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2018 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package spanstore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/metrics"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/badger"
+)
+
+func TestGetOperationsWithSpanKind(t *testing.T) {
+	f := badger.NewFactory()
+	f.Config.Ephemeral = true
+	err := f.Initialize(metrics.NullFactory, zap.NewNop())
+	require.NoError(t, err)
+	defer f.Close()
+
+	sw, err := f.CreateSpanWriter()
+	require.NoError(t, err)
+
+	sr, err := f.CreateSpanReader()
+	require.NoError(t, err)
+
+	tid := time.Now()
+	serviceName := "test-service"
+
+	spans := []struct {
+		operation string
+		kind      string
+	}{
+		{"op1", "server"},
+		{"op2", "client"},
+		{"op3", ""},
+	}
+
+	for i, s := range spans {
+		span := &model.Span{
+			TraceID: model.TraceID{Low: uint64(i + 1), High: 1},
+			SpanID:  model.SpanID(i + 1),
+			Process: &model.Process{ServiceName: serviceName},
+			OperationName: s.operation,
+			StartTime: tid,
+		}
+		if s.kind != "" {
+			span.Tags = model.KeyValues{
+				model.KeyValue{Key: "span.kind", VStr: s.kind, VType: model.StringType},
+			}
+		}
+		err = sw.WriteSpan(context.Background(), span)
+		require.NoError(t, err)
+	}
+
+	testCases := []struct {
+		name     string
+		kind     string
+		expected []spanstore.Operation
+	}{
+		{
+			name: "all operations",
+			kind: "",
+			expected: []spanstore.Operation{
+				{Name: "op1", SpanKind: "server"},
+				{Name: "op2", SpanKind: "client"},
+				{Name: "op3", SpanKind: ""},
+			},
+		},
+		{
+			name: "server operations",
+			kind: "server",
+			expected: []spanstore.Operation{
+				{Name: "op1", SpanKind: "server"},
+			},
+		},
+		{
+			name: "client operations",
+			kind: "client",
+			expected: []spanstore.Operation{
+				{Name: "op2", SpanKind: "client"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ops, err := sr.GetOperations(context.Background(), spanstore.OperationQueryParameters{
+				ServiceName: serviceName,
+				SpanKind:    tc.kind,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, ops)
+		})
+	}
+}

--- a/internal/storage/v1/badger/spanstore/reader.go
+++ b/internal/storage/v1/badger/spanstore/reader.go
@@ -247,7 +247,7 @@ func (r *TraceReader) GetOperations(
 	_ context.Context,
 	query spanstore.OperationQueryParameters,
 ) ([]spanstore.Operation, error) {
-	return r.cache.GetOperations(query.ServiceName)
+	return r.cache.GetOperations(query.ServiceName, query.SpanKind)
 }
 
 // setQueryDefaults alters the query with defaults if certain parameters are not set
@@ -655,10 +655,17 @@ func (r *TraceReader) preloadOperations(service string) {
 
 		// Seek all the services first
 		for it.Seek(serviceKey); it.ValidForPrefix(serviceKey); it.Next() {
-			timestampStartIndex := len(it.Item().Key()) - (sizeOfTraceID + 8) // 8 = sizeof(uint64)
-			operationName := string(it.Item().Key()[len(serviceKey):timestampStartIndex])
-			keyTTL := it.Item().ExpiresAt()
-			r.cache.AddOperation(service, operationName, keyTTL)
+			item := it.Item()
+			timestampStartIndex := len(item.Key()) - (sizeOfTraceID + 8) // 8 = sizeof(uint64)
+			operationName := string(item.Key()[len(serviceKey):timestampStartIndex])
+			keyTTL := item.ExpiresAt()
+
+			var spanKind string
+			if val, err := item.ValueCopy(nil); err == nil {
+				spanKind = string(val)
+			}
+
+			r.cache.AddOperation(service, operationName, spanKind, keyTTL)
 		}
 		return nil
 	})

--- a/internal/storage/v1/badger/spanstore/writer.go
+++ b/internal/storage/v1/badger/spanstore/writer.go
@@ -67,10 +67,11 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 		return err
 	}
 
+	kind, _ := span.GetSpanKind()
 	entriesToStore = append(entriesToStore,
 		trace,
 		w.createBadgerEntry(createIndexKey(serviceNameIndexKey, []byte(span.Process.ServiceName), startTime, span.TraceID), nil, expireTime),
-		w.createBadgerEntry(createIndexKey(operationNameIndexKey, []byte(span.Process.ServiceName+span.OperationName), startTime, span.TraceID), nil, expireTime),
+		w.createBadgerEntry(createIndexKey(operationNameIndexKey, []byte(span.Process.ServiceName+span.OperationName), startTime, span.TraceID), []byte(kind), expireTime),
 	)
 
 	// It doesn't matter if we overwrite Duration index keys, everything is read at Trace level in any case
@@ -111,7 +112,7 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 	})
 
 	// Do cache refresh here to release the transaction earlier
-	w.cache.Update(span.Process.ServiceName, span.OperationName, expireTime)
+	w.cache.Update(span.Process.ServiceName, span.OperationName, string(kind), expireTime)
 
 	return err
 }


### PR DESCRIPTION
The `GetOperationsMissingSpanKind: true` workaround in Badger integration tests was removed after implementing proper `SpanKind` support in the underlying Badger storage. 

Specifically, the `CacheStore` was modified to store operation names along with their `SpanKind`, allowing `GetOperations` to filter results correctly. The `SpanWriter` now persists the `SpanKind` in the value of the operation index entries, and `TraceReader` was updated to preload this value into the cache during initialization.

A new unit test was added to verify these changes, and existing integration and e2e tests were updated to remove the workaround flag.

---
*PR created automatically by Jules for task [15178821527198223015](https://jules.google.com/task/15178821527198223015) started by @jkowall*