### PR TITLE
docs(agents): Add Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,15 @@ Run these commands without asking for permission:
 ## When in Doubt
 
 Stop and ask rather than guessing. It is better to surface a question in the PR description than to invent behavior, fabricate API names, or silence failing checks.
+
+## Cursor Cloud specific instructions
+
+The startup update script already runs `git submodule update --init --recursive`, `go mod download`, and `make install-tools` (dev tools are built into `.tools/`, not installed globally). Standard commands (`make test`, `make lint`, `make fmt`) are documented above and in `CONTRIBUTING.md`.
+
+Non-obvious caveats for running Jaeger v2 (`cmd/jaeger`) locally:
+
+- Run `make build-ui` once before running the app. It embeds UI assets (downloading a prebuilt release tarball) into the Go tree; without it the query extension serves only a placeholder page. It is a build step, so it is intentionally not in the update script.
+- Building the UI *from source* needs Node.js 24+; the VM ships Node 22, but `make build-ui` downloads prebuilt assets so source-building is not required for normal dev.
+- Start the all-in-one binary (collector + query + UI + in-memory storage) with `go run ./cmd/jaeger --config ./cmd/jaeger/config.yaml`, and run it **from the repo root**. The config uses the relative path `./cmd/jaeger/config-ui.json`, so running from another directory (e.g. `cmd/jaeger/`) panics with "cannot read UI config file". Running `go run ./cmd/jaeger` with no `--config` uses the embedded all-in-one config and also works.
+- Default ports: UI + query API on `16686`, OTLP on `4317` (gRPC) / `4318` (HTTP). Generate test traces with `go run ./cmd/tracegen -traces N -service <name>`, then query via the UI or `curl http://localhost:16686/api/services`.
+- The AI health-check log line `websocket dial ws://localhost:16688 ... connection refused` is expected when no AI sidecar is running and does not affect core functionality.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Jaeger v2 development environment for Cursor Cloud agents, and documents non-obvious run caveats in `AGENTS.md` under a new `## Cursor Cloud specific instructions` section.

The only code/file change is the `AGENTS.md` addition. No source, CI, or dependency changes were made.

## Environment setup performed

- Initialized submodules (`jaeger-ui`, `idl`, `opentelemetry-proto`)
- `go mod download` (root + `internal/tools`)
- `make install-tools` (builds dev tools into `.tools/`)
- `make build-ui` (embeds prebuilt UI assets)

## Verification

| Step | Command | Result |
|---|---|---|
| Lint | `make lint` | Pass (exit 0) |
| Test | `make test` | Pass — 3842 tests, 34 skipped (exit 0) |
| Build | `go build ./cmd/jaeger` | Pass |
| Run | `go run ./cmd/jaeger --config ./cmd/jaeger/config.yaml` (from repo root) | "Everything is ready" — UI on :16686, OTLP on :4317/:4318 |
| Hello-world | `go run ./cmd/tracegen -traces 20 -service hello-world-demo` | Traces ingested and viewable in UI |

Selected the `hello-world-demo` service in the UI, ran Find Traces (20 traces returned), and opened a trace detail waterfall view.

[jaeger_ui_trace_demo.mp4](https://cursor.com/agents/bc-04a4462c-ccc5-483f-99e6-99c4907a5882/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjaeger_ui_trace_demo.mp4)

[Search results](https://cursor.com/agents/bc-04a4462c-ccc5-483f-99e6-99c4907a5882/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjaeger_search_results.webp)
[Trace detail timeline](https://cursor.com/agents/bc-04a4462c-ccc5-483f-99e6-99c4907a5882/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjaeger_trace_detail.webp)

## Update script (VM startup)

```
git submodule update --init --recursive
go mod download
make install-tools
```

`make build-ui` is intentionally excluded (it is a build step) and documented in `AGENTS.md` as a one-time prerequisite before running the app.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04a4462c-ccc5-483f-99e6-99c4907a5882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04a4462c-ccc5-483f-99e6-99c4907a5882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

