### PR TITLE
Update jkowall and yurishkuro employer affiliations

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,11 +3,11 @@ The current Maintainers Group for the Jaeger Project consists of:
 | Name | Employer | Responsibilities |
 | ---- | -------- | ---------------- |
 | [@albertteoh](https://github.com/albertteoh) | PackSmith | ALL |
-| [@jkowall](https://github.com/jkowall) | Paessler | ALL |
+| [@jkowall](https://github.com/jkowall) | Spacelift | ALL |
 | [@joe-elliott](https://github.com/joe-elliott) | Grafana Labs | ALL |
 | [@mahadzaryab1](https://github.com/mahadzaryab1) | Bloomberg | ALL |
 | [@pavolloffay](https://github.com/pavolloffay) | RedHat | ALL |
-| [@yurishkuro](https://github.com/yurishkuro) | Meta | ALL |
+| [@yurishkuro](https://github.com/yurishkuro) | Airbnb | ALL |
 
 This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Update Jonah Kowall’s employer affiliation from Paessler to Spacelift and Yuri Shkuro’s employer affiliation from Meta to Airbnb in `MAINTAINERS.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba3d9ea3-f2bb-4013-a6b8-a9bd21fa22c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba3d9ea3-f2bb-4013-a6b8-a9bd21fa22c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

