### PR TITLE
fix(security): Clear open CodeQL and Scorecard token-permission alerts

### DIFF
--- a/.github/workflows/ci-orchestrator-stage3.yml
+++ b/.github/workflows/ci-orchestrator-stage3.yml
@@ -41,6 +41,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      # Required to upload CodeQL SARIF to the code-scanning API.
       security-events: write
     uses: ./.github/workflows/codeql.yml
     secrets: inherit

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -192,6 +192,7 @@ jobs:
       actions: read
       contents: read
       packages: read
+      # Ceiling for CodeQL SARIF upload in the called stage3 workflow.
       security-events: write
     uses: ./.github/workflows/ci-orchestrator-stage3.yml
     secrets: inherit
@@ -226,6 +227,7 @@ jobs:
       actions: read
       contents: read
       packages: read
+      # Ceiling for CodeQL SARIF upload in the called stage3 workflow.
       security-events: write
     uses: ./.github/workflows/ci-orchestrator-stage3.yml
     secrets: inherit
@@ -303,6 +305,7 @@ jobs:
     needs: [ci-success]
     if: always() && needs.ci-success.result == 'success'
     permissions:
+      # Ceiling for actions/cache save in the called summary workflow.
       actions: write
       contents: read
     uses: ./.github/workflows/ci-summary-report.yml

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -20,6 +20,10 @@ on:
         type: boolean
         description: Allow overwriting artifacts.
 
+# Scorecard Token-Permissions: read-only default; writes stay on the publish job.
+permissions:
+  contents: read
+
 jobs:
   publish-release:
     permissions:

--- a/.github/workflows/ci-summary-report-publish.yml
+++ b/.github/workflows/ci-summary-report-publish.yml
@@ -30,14 +30,17 @@ on:
       pr_number:
         description: 'PR number to post summary report for'
         required: true
+# Scorecard Token-Permissions: keep writes on the publish job only.
 permissions:
   contents: read
-  pull-requests: write
-  checks: write
-  actions: read
 jobs:
   publish:
     name: Post Summary
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+      actions: read
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success' ||

--- a/.github/workflows/ci-summary-report.yml
+++ b/.github/workflows/ci-summary-report.yml
@@ -12,13 +12,16 @@
 name: CI Summary Report
 on:
   workflow_call:
+# Scorecard Token-Permissions: keep actions: write on the job that saves cache.
 permissions:
   contents: read
-  actions: write  # required for actions/cache save and gh run download
 
 jobs:
   summary-report:
     name: Summary Report
+    permissions:
+      contents: read
+      actions: write  # required for actions/cache save and gh run download
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser.go
@@ -122,11 +122,13 @@ func parseFindTracesQuery(q url.Values) (*querysvc.TraceQueryParams, error) {
 		searchDepthParam = paramNumTraces
 	}
 	if n != "" {
-		searchDepth, err := strconv.Atoi(n)
+		// bitSize 32 keeps searchDepth inside the protobuf int32 the gRPC
+		// storage client later encodes, instead of wrapping on int32(...).
+		searchDepth, err := strconv.ParseInt(n, 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("malformed parameter %s: %w", searchDepthParam, err)
 		}
-		queryParams.SearchDepth = searchDepth
+		queryParams.SearchDepth = int(searchDepth)
 	} else {
 		queryParams.SearchDepth = defaultSearchDepth
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser_test.go
@@ -4,7 +4,9 @@
 package apiv3
 
 import (
+	"math"
 	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
@@ -87,6 +89,19 @@ func TestParseFindTracesQuery(t *testing.T) {
 		got, err := parseFindTracesQuery(q)
 		require.NoError(t, err)
 		assert.Equal(t, 7, got.SearchDepth)
+	})
+
+	t.Run("search depth at int32 bounds", func(t *testing.T) {
+		for _, depth := range []int{math.MaxInt32, math.MinInt32} {
+			q := url.Values{}
+			q.Set(paramTimeMin, goodMin)
+			q.Set(paramTimeMax, goodMax)
+			q.Set(paramSearchDepth, strconv.Itoa(depth))
+
+			got, err := parseFindTracesQuery(q)
+			require.NoError(t, err)
+			assert.Equal(t, depth, got.SearchDepth)
+		}
 	})
 
 	t.Run("attributes", func(t *testing.T) {
@@ -175,6 +190,21 @@ func TestParseFindTracesQuery(t *testing.T) {
 		{
 			name:    "bad num_traces (deprecated alias)",
 			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramNumTraces: "NaN"},
+			wantErr: "malformed parameter " + paramNumTraces,
+		},
+		{
+			name:    "searchDepth above int32",
+			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramSearchDepth: "2147483648"},
+			wantErr: "malformed parameter " + paramSearchDepth,
+		},
+		{
+			name:    "searchDepth below int32",
+			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramSearchDepth: "-2147483649"},
+			wantErr: "malformed parameter " + paramSearchDepth,
+		},
+		{
+			name:    "num_traces above int32",
+			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramNumTraces: "2147483648"},
 			wantErr: "malformed parameter " + paramNumTraces,
 		},
 		{

--- a/internal/storage/v2/grpc/tracereader.go
+++ b/internal/storage/v2/grpc/tracereader.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"math"
 	"sync/atomic"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -265,6 +266,9 @@ func toProtoQueryParameters(t tracestore.TraceQueryParams) (*storage.TraceQueryP
 	if err != nil {
 		return nil, fmt.Errorf("cannot send the query filter: %w", err)
 	}
+	if t.SearchDepth < math.MinInt32 || t.SearchDepth > math.MaxInt32 {
+		return nil, fmt.Errorf("SearchDepth must be in [%d, %d]", math.MinInt32, math.MaxInt32)
+	}
 	return &storage.TraceQueryParameters{
 		ServiceName:   t.ServiceName,
 		OperationName: t.OperationName,
@@ -273,7 +277,7 @@ func toProtoQueryParameters(t tracestore.TraceQueryParams) (*storage.TraceQueryP
 		StartTimeMax:  t.StartTimeMax,
 		DurationMin:   t.DurationMin,
 		DurationMax:   t.DurationMax,
-		SearchDepth:   int32(t.SearchDepth), //nolint:gosec // G115
+		SearchDepth:   int32(t.SearchDepth),
 		Filter:        filter,
 	}, nil
 }

--- a/internal/storage/v2/grpc/tracereader_test.go
+++ b/internal/storage/v2/grpc/tracereader_test.go
@@ -6,6 +6,7 @@ package grpc
 import (
 	"context"
 	"errors"
+	"math"
 	"net"
 	"testing"
 	"time"
@@ -1003,4 +1004,28 @@ func TestTraceReader_RefusesUnencodableFilter(t *testing.T) {
 			assert.ErrorContains(t, err, "cannot send the query filter")
 		})
 	}
+}
+
+func TestToProtoQueryParameters_SearchDepth(t *testing.T) {
+	t.Run("int32 bounds encode as-is", func(t *testing.T) {
+		for _, depth := range []int{0, 1, math.MaxInt32, math.MinInt32} {
+			got, err := toProtoQueryParameters(tracestore.TraceQueryParams{
+				Attributes:  pcommon.NewMap(),
+				SearchDepth: depth,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, int32(depth), got.GetSearchDepth())
+		}
+	})
+
+	t.Run("outside int32 is refused", func(t *testing.T) {
+		for _, depth := range []int{math.MaxInt32 + 1, math.MinInt32 - 1} {
+			_, err := toProtoQueryParameters(tracestore.TraceQueryParams{
+				Attributes:  pcommon.NewMap(),
+				SearchDepth: depth,
+			})
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "SearchDepth must be in")
+		}
+	})
 }

--- a/scripts/lint/replace_license_headers.py
+++ b/scripts/lint/replace_license_headers.py
@@ -4,19 +4,84 @@
 
 # Replace Apache 2.0 license headers with SPDX license identifiers.
 
-import re
 import sys
+
+# Line-oriented match for the old multi-line Apache header. The previous
+# DOTALL regex used overlapping `// Copyright.*?` repetition and was a
+# ReDoS risk (CodeQL py/redos). Each pass below consumes a whole line.
+_COPYRIGHT_PREFIX = '// Copyright'
+_BLANK_COMMENT = '//'
+_LICENSE_START = '// Licensed under the Apache License'
+_LICENSE_END = 'limitations under the License.'
+
+
+def _split_first_line(text, start):
+    newline = text.find('\n', start)
+    if newline == -1:
+        return None, None, None
+    return text[start:newline], newline, newline + 1
+
+
+def match_old_apache_header(content):
+    """Return (old_header, match_end) for a leading Apache header, or (None, 0).
+
+    old_header is the text through 'limitations under the License.' (the old
+    regex capture). match_end is the index after the trailing whitespace and
+    newline the old regex consumed, so replacement still drops that suffix.
+    """
+    if not content.startswith(_COPYRIGHT_PREFIX):
+        return None, 0
+
+    # First line is a copyright line. Consume later // comments until the
+    # blank `//` that introduces the Apache license block. Intervening
+    # comments (extra copyrights, an existing SPDX line) are part of the
+    # old header and must stay in the capture so the skip-if-SPDX path runs.
+    line, _, pos = _split_first_line(content, 0)
+    if line is None:
+        return None, 0
+
+    while True:
+        line, _, next_pos = _split_first_line(content, pos)
+        if line is None:
+            return None, 0
+        if line == _BLANK_COMMENT:
+            peek, _, peek_next = _split_first_line(content, next_pos)
+            if peek is not None and peek.startswith(_LICENSE_START):
+                pos = peek_next
+                break
+        if not line.startswith('//'):
+            return None, 0
+        pos = next_pos
+
+    while True:
+        line, _, next_pos = _split_first_line(content, pos)
+        if line is None or not line.startswith('//'):
+            return None, 0
+        if _LICENSE_END in line:
+            # Capture ends at 'License.', matching the old regex group.
+            # Then consume `\s*\n` (longest whitespace prefix that ends
+            # on a newline) so the replacement still drops that suffix.
+            end_in_line = line.find(_LICENSE_END) + len(_LICENSE_END)
+            old_header_end = pos + end_in_line
+            rest = content[old_header_end:]
+            last_nl = -1
+            i = 0
+            while i < len(rest) and rest[i] in ' \t\r\n\f\v':
+                if rest[i] == '\n':
+                    last_nl = i
+                i += 1
+            if last_nl == -1:
+                return None, 0
+            return content[:old_header_end], old_header_end + last_nl + 1
+        pos = next_pos
+
 
 def replace_license_header(file_path, dry_run=False):
     with open(file_path, 'r') as file:
         content = file.read()
 
-    # Pattern to match the entire old header, including multiple copyright lines
-    header_pattern = re.compile(r'(?s)^(// Copyright.*?(?:\n// Copyright.*?)*\n//\n// Licensed under the Apache License.*?limitations under the License\.)\s*\n')
-
-    match = header_pattern.match(content)
-    if match:
-        old_header = match.group(1)
+    old_header, match_end = match_old_apache_header(content)
+    if old_header is not None:
         if "SPDX-License-Identifier: Apache-2.0" in old_header:
             print(f"Skipping {file_path}: SPDX identifier already present")
             return False
@@ -25,11 +90,13 @@ def replace_license_header(file_path, dry_run=False):
             print(f"Would update {file_path}")
             return True
 
-        # Preserve all copyright lines and add SPDX identifier
-        copyright_lines = re.findall(r'// Copyright.*', old_header)
+        copyright_lines = [
+            line for line in old_header.splitlines()
+            if line.startswith(_COPYRIGHT_PREFIX)
+        ]
         new_header = "\n".join(copyright_lines) + "\n// SPDX-License-Identifier: Apache-2.0\n\n"
 
-        new_content = header_pattern.sub(new_header, content, count=1)
+        new_content = new_header + content[match_end:]
 
         with open(file_path, 'w') as file:
             file.write(new_content)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Which problem is this PR solving?

Closes the currently open GitHub code-scanning alerts on `jaegertracing/jaeger` (Security → Code scanning). There is no separate tracking issue; the work is scoped to those alerts.

**Intended merge target:** `jaegertracing/jaeger:main` from `jkowall/jaeger-F:cursor/fix-code-scanning-alerts-5ae2`.

Open against upstream: https://github.com/jaegertracing/jaeger/compare/main...jkowall:jaeger-F:cursor/fix-code-scanning-alerts-5ae2?expand=1

## Short description of the changes

- **CodeQL #267 (`go/incorrect-integer-conversion`)** — parse `query.searchDepth` / `query.num_traces` with `strconv.ParseInt(..., 10, 32)` and refuse values outside int32 before `toProtoQueryParameters` encodes `SearchDepth` as protobuf `int32`. In-range API values (including `MaxInt32` / `MinInt32`) are unchanged; oversized values that previously wrapped are now `malformed parameter`.
- **CodeQL #167 (`py/redos`)** — replace the DOTALL `// Copyright.*?` repetition in `scripts/lint/replace_license_headers.py` with a line-oriented scan. Normal Apache-header rewrite and the skip-if-SPDX path are unchanged.
- **Scorecard TokenPermissionsID** — add a top-level `contents: read` default on `ci-release.yml`, and move `checks: write` / `actions: write` off the top level of the summary-report workflows onto the jobs that need them.

## Alerts that should close

| Alert | Rule | Change |
| --- | --- | --- |
| #267 | `go/incorrect-integer-conversion` | bit-size-safe parse + range check before `int32` |
| #167 | `py/redos` | ReDoS-safe header matcher |
| #260 | TokenPermissionsID (missing top-level permissions) | `permissions: contents: read` on `ci-release.yml` |
| #262 | TokenPermissionsID (topLevel `checks: write`) | job-level writes on `ci-summary-report-publish.yml` |
| #263 | TokenPermissionsID (topLevel `actions: write`) | job-level write on `ci-summary-report.yml` |

## Remaining intentional Scorecard exceptions

These writes are required and stay at **job** level (top-level default is already `contents: read`):

| Alert | Permission | Why it stays |
| --- | --- | --- |
| #256 | `security-events: write` on `ci-orchestrator-stage3.yml` `codeql` | CodeQL SARIF upload |
| #257–#259 | `security-events: write` / `actions: write` on `ci-orchestrator.yml` | ceiling for the called CodeQL job and `actions/cache` save in the summary workflow |
| #261 | `contents: write` on `ci-release.yml` `publish-release` | upload release artifacts with `GITHUB_TOKEN` |

Scorecard still reports those job-level writes even when they do not reduce the Token-Permissions score. Removing them would break SARIF upload, cache save, or release publish.

## How was it tested?

- Unit tests for `parseFindTracesQuery` at int32 bounds and overflow (`parseFindTracesQuery` 100% coverage).
- Unit tests for `toProtoQueryParameters` accepting in-range `SearchDepth` and refusing overflow (`toProtoQueryParameters` 100% coverage).
- Compared the new license-header matcher against the old regex on typical, multi-copyright, hybrid SPDX, and missing-header inputs; rewrite output unchanged. A 20k-line `// Copyright` file completes in milliseconds.
- `make fmt`, `make lint` (0 issues), `make test` (4918 tests, 0 failures).

## Checklist

- [x] I have read [CONTRIBUTING_GUIDELINES.md](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md)
- [x] I have signed all commits
- [x] New / changed code is covered by tests

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f36540c5-50b9-4d02-b7f5-09f31cbd5ae2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f36540c5-50b9-4d02-b7f5-09f31cbd5ae2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

