### PR TITLE
fix(query): Cap SearchDepth at 10000 and reject negatives

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser.go
@@ -22,6 +22,9 @@ import (
 
 const (
 	defaultSearchDepth = 100
+	// maxSearchDepth matches ClickHouse's default MaxSearchDepth: a search
+	// window, not an int32 bound. The HTTP default is 100; MCP defaults to 10.
+	maxSearchDepth = 10000
 
 	paramTraceID = "trace_id" // path parameter
 
@@ -122,11 +125,12 @@ func parseFindTracesQuery(q url.Values) (*querysvc.TraceQueryParams, error) {
 		searchDepthParam = paramNumTraces
 	}
 	if n != "" {
-		// bitSize 32 keeps searchDepth inside the protobuf int32 the gRPC
-		// storage client later encodes, instead of wrapping on int32(...).
 		searchDepth, err := strconv.ParseInt(n, 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("malformed parameter %s: %w", searchDepthParam, err)
+		}
+		if searchDepth < 0 || searchDepth > maxSearchDepth {
+			return nil, fmt.Errorf("malformed parameter %s: search depth must be in [0, %d]", searchDepthParam, maxSearchDepth)
 		}
 		queryParams.SearchDepth = int(searchDepth)
 	} else {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser_test.go
@@ -4,7 +4,6 @@
 package apiv3
 
 import (
-	"math"
 	"net/url"
 	"strconv"
 	"testing"
@@ -91,8 +90,8 @@ func TestParseFindTracesQuery(t *testing.T) {
 		assert.Equal(t, 7, got.SearchDepth)
 	})
 
-	t.Run("search depth at int32 bounds", func(t *testing.T) {
-		for _, depth := range []int{math.MaxInt32, math.MinInt32} {
+	t.Run("search depth at zero and max", func(t *testing.T) {
+		for _, depth := range []int{0, maxSearchDepth} {
 			q := url.Values{}
 			q.Set(paramTimeMin, goodMin)
 			q.Set(paramTimeMax, goodMax)
@@ -193,18 +192,18 @@ func TestParseFindTracesQuery(t *testing.T) {
 			wantErr: "malformed parameter " + paramNumTraces,
 		},
 		{
-			name:    "searchDepth above int32",
-			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramSearchDepth: "2147483648"},
+			name:    "searchDepth negative",
+			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramSearchDepth: "-1"},
 			wantErr: "malformed parameter " + paramSearchDepth,
 		},
 		{
-			name:    "searchDepth below int32",
-			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramSearchDepth: "-2147483649"},
+			name:    "searchDepth above max",
+			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramSearchDepth: "10001"},
 			wantErr: "malformed parameter " + paramSearchDepth,
 		},
 		{
-			name:    "num_traces above int32",
-			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramNumTraces: "2147483648"},
+			name:    "num_traces above max",
+			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramNumTraces: "10001"},
 			wantErr: "malformed parameter " + paramNumTraces,
 		},
 		{

--- a/internal/storage/v2/grpc/tracereader.go
+++ b/internal/storage/v2/grpc/tracereader.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"iter"
-	"math"
 	"sync/atomic"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -23,6 +22,11 @@ import (
 	expressionproto "github.com/jaegertracing/jaeger/internal/proto/expression/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
+
+// maxSearchDepth is the largest SearchDepth this client will encode. It matches
+// ClickHouse's default MaxSearchDepth (10000): a search window, not an int32
+// bound. 0 is valid and means "backend default" on several stores.
+const maxSearchDepth = 10000
 
 var _ tracestore.Reader = (*TraceReader)(nil)
 
@@ -266,8 +270,8 @@ func toProtoQueryParameters(t tracestore.TraceQueryParams) (*storage.TraceQueryP
 	if err != nil {
 		return nil, fmt.Errorf("cannot send the query filter: %w", err)
 	}
-	if t.SearchDepth < math.MinInt32 || t.SearchDepth > math.MaxInt32 {
-		return nil, fmt.Errorf("SearchDepth must be in [%d, %d]", math.MinInt32, math.MaxInt32)
+	if t.SearchDepth < 0 || t.SearchDepth > maxSearchDepth {
+		return nil, fmt.Errorf("SearchDepth must be in [0, %d]", maxSearchDepth)
 	}
 	return &storage.TraceQueryParameters{
 		ServiceName:   t.ServiceName,

--- a/internal/storage/v2/grpc/tracereader_test.go
+++ b/internal/storage/v2/grpc/tracereader_test.go
@@ -6,7 +6,6 @@ package grpc
 import (
 	"context"
 	"errors"
-	"math"
 	"net"
 	"testing"
 	"time"
@@ -1007,8 +1006,8 @@ func TestTraceReader_RefusesUnencodableFilter(t *testing.T) {
 }
 
 func TestToProtoQueryParameters_SearchDepth(t *testing.T) {
-	t.Run("int32 bounds encode as-is", func(t *testing.T) {
-		for _, depth := range []int{0, 1, math.MaxInt32, math.MinInt32} {
+	t.Run("zero and max encode as-is", func(t *testing.T) {
+		for _, depth := range []int{0, 1, maxSearchDepth} {
 			got, err := toProtoQueryParameters(tracestore.TraceQueryParams{
 				Attributes:  pcommon.NewMap(),
 				SearchDepth: depth,
@@ -1018,14 +1017,14 @@ func TestToProtoQueryParameters_SearchDepth(t *testing.T) {
 		}
 	})
 
-	t.Run("outside int32 is refused", func(t *testing.T) {
-		for _, depth := range []int{math.MaxInt32 + 1, math.MinInt32 - 1} {
+	t.Run("negative and above max are refused", func(t *testing.T) {
+		for _, depth := range []int{-1, maxSearchDepth + 1} {
 			_, err := toProtoQueryParameters(tracestore.TraceQueryParams{
 				Attributes:  pcommon.NewMap(),
 				SearchDepth: depth,
 			})
 			require.Error(t, err)
-			assert.ErrorContains(t, err, "SearchDepth must be in")
+			assert.ErrorContains(t, err, "SearchDepth must be in [0,")
 		}
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Which problem is this PR solving?

Follow-up to #9488. Yuri reviewed the `int32` bound on `toProtoQueryParameters` after that PR merged:

> it cannot be negative and math.MaxInt32 is way too high of a ceiling

https://github.com/jaegertracing/jaeger/pull/9488#discussion_r3941465591

#9488 landed the CodeQL `go/incorrect-integer-conversion` fix with a `MinInt32`/`MaxInt32` check. This PR replaces that with a semantic SearchDepth range.

## Short description of the changes

- Require `SearchDepth` in `[0, 10000]` in `toProtoQueryParameters` (`internal/storage/v2/grpc/tracereader.go`).
- Same check in the HTTP parser (`query.searchDepth` / `query.num_traces`) so oversized values never reach the encoder.
- `10000` is ClickHouse's default `MaxSearchDepth` (existing search-window ceiling in this repo). Zero stays valid (backend default). API default remains 100.
- Cherry-pick of `f5b774ca8c49d52146d95c7f9257b013e0264c29`, which missed the #9488 merge (`aec70b8`).

Does not recreate the Scorecard / ReDoS commits from #9488.

## How was it tested?

- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/ ./internal/storage/v2/grpc/`
- 0 and 10000 accepted; `-1` and `10001` refused.

## Checklist

- [x] I have read [CONTRIBUTING_GUIDELINES.md](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md)
- [x] I have signed all commits
- [x] New / changed code is covered by tests

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f36540c5-50b9-4d02-b7f5-09f31cbd5ae2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f36540c5-50b9-4d02-b7f5-09f31cbd5ae2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

